### PR TITLE
added Rust-Hackchat-Bot

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ Want to list your software that you've made? It's as easy as forking this reposi
 |Python|[hiyobot](https://github.com/Hiyoteam/hiyobot)|simple & powerful python bot framework for hack.chat|
 |JavaScript|[hack.chat.js](https://github.com/WebFreak001/hack.chat.js)|*No longer maintained* API wrapper for hack.chat using ws package|
 |Rust|[rust-hackchat](https://github.com/gkbrk/rust-hackchat)|A hack.chat API in Rust.|
+|Rust|[Rust-Hackchat-Bot](https://github.com/JankieQwQ/rust-hackchat-bot)|An event-driven Rust library for hack.chat|
 |C#|[HackchatSharp](https://github.com/UnrealSecurity/HackchatSharp)|HackchatSharp is a C# library for hack.chat.|
 
 ### Android apps:


### PR DESCRIPTION
Rust-Hackchat-Bot is an OOP Library of HackChat bots. It allows users to easily run bots on HackChat using Rust.